### PR TITLE
Fix colours and Umlaut text

### DIFF
--- a/client/src/components/ui/status-indicator.tsx
+++ b/client/src/components/ui/status-indicator.tsx
@@ -7,7 +7,7 @@ export function StatusIndicator({ status }: StatusIndicatorProps) {
     switch (status) {
       case "active":
         return {
-          color: "bg-green-500",
+          color: "bg-foreground",
           text: "GPS an",
           pulse: false,
         };

--- a/client/src/pages/compass.tsx
+++ b/client/src/pages/compass.tsx
@@ -275,12 +275,12 @@ export default function CompassPage() {
                 {isAligned ? (
                   <div>
                     <div className="text-4xl mb-2">🎯</div>
-                    <div className="text-lg font-semibold text-green-600">Auf das Hermannsdenkmal ausgerichtet!</div>
+                    <div className="text-lg font-semibold text-primary">Auf das Hermannsdenkmal ausgerichtet!</div>
                   </div>
                 ) : (
                   <div>
                     <div className="text-4xl mb-2">🧭</div>
-                    <div className="text-lg font-semibold text-muted-foreground">Drehe dich, bis der Pfeil \u00fcbereinstimmt</div>
+                    <div className="text-lg font-semibold text-muted-foreground">Drehe dich, bis der Pfeil übereinstimmt</div>
                   </div>
                 )}
               </CardContent>


### PR DESCRIPTION
## Summary
- change success message colour to match Arminia Bielefeld scheme
- switch GPS active indicator from green to black
- fix German string with escaped umlaut

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_683b1656c2d4832faa9ab23c4db28de2